### PR TITLE
:rocket: added admin template selector override

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,12 @@ Set label and color for current environment:
     ENVIRONMENT_NAME = "Production server"
     ENVIRONMENT_COLOR = "#FF2222"
 
+Override django admin selector if necessary (default: body), e.g: grappelli:
+
+.. code-block:: python
+
+    ENVIRONMENT_ADMIN_SELECTOR = "grp-header"
+
 Screenshots
 -----------
 

--- a/django_admin_env_notice/context_processors.py
+++ b/django_admin_env_notice/context_processors.py
@@ -5,4 +5,6 @@ def from_settings(request):
     return {
         'ENVIRONMENT_NAME': getattr(settings, 'ENVIRONMENT_NAME', None),
         'ENVIRONMENT_COLOR': getattr(settings, 'ENVIRONMENT_COLOR', None),
+        'ENVIRONMENT_ADMIN_SELECTOR': getattr(
+            settings, 'ENVIRONMENT_ADMIN_SELECTOR', 'body'),
     }

--- a/django_admin_env_notice/templates/admin/base_site.html
+++ b/django_admin_env_notice/templates/admin/base_site.html
@@ -3,7 +3,7 @@
 {% if ENVIRONMENT_NAME and ENVIRONMENT_COLOR %}
 <!-- Environment notice -->
 <style type="text/css">
-    body:before {
+    {{ ENVIRONMENT_ADMIN_SELECTOR}}:before {
         display: block;
         line-height: 35px;
         text-align: center;

--- a/tests/test.py
+++ b/tests/test.py
@@ -27,6 +27,25 @@ class AdminEnvironmentTestCase(LiveServerTestCase):
         self.assertContains(response, 'content: "Production server"')
         self.assertContains(response, "background-color: #FF2222")
 
+    @override_settings(
+        ENVIRONMENT_NAME="Production server",
+        ENVIRONMENT_COLOR="#FF2222"
+    )
+    def test_use_body_as_admin_selector_if_no_setting(self):
+        """ Should use body as selector if settings was not provided """
+        response = self.client.get('/admin/')
+        self.assertContains(response, 'body:before {')
+
+    @override_settings(
+        ENVIRONMENT_NAME="Production server",
+        ENVIRONMENT_COLOR="#FF2222",
+        ENVIRONMENT_ADMIN_SELECTOR='.container'
+    )
+    def test_add_admin_selector_code_on_correct_settings(self):
+        """ Should use the selector if settings was provided """
+        response = self.client.get('/admin/')
+        self.assertContains(response, '.container:before {')
+
     @override_settings(ENVIRONMENT_NAME="Production server", ENVIRONMENT_COLOR="#FF2222")
     def test_should_work_on_other_admin_pages(self):
         """ Should include css code to other admin pages as well """


### PR DESCRIPTION
Basically we just need a setting to override the template selector so that when we have x,y,z admin theme setup we can hook it up however that theme works, in this case grappelli.