### PR TITLE
Scroll the environment label through the page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,12 @@ Override django admin selector if necessary (default: body), e.g: grappelli:
 
     ENVIRONMENT_ADMIN_SELECTOR = "grp-header"
 
+Optionally, se the environment banner to float over instead of being fixed to the top:
+
+.. code-block:: python
+
+    ENVIRONMENT_FLOAT = True
+
 Screenshots
 -----------
 

--- a/django_admin_env_notice/context_processors.py
+++ b/django_admin_env_notice/context_processors.py
@@ -7,4 +7,5 @@ def from_settings(request):
         'ENVIRONMENT_COLOR': getattr(settings, 'ENVIRONMENT_COLOR', None),
         'ENVIRONMENT_ADMIN_SELECTOR': getattr(
             settings, 'ENVIRONMENT_ADMIN_SELECTOR', 'body'),
+        'ENVIRONMENT_FLOAT': getattr(settings, 'ENVIRONMENT_FLOAT', False),
     }

--- a/django_admin_env_notice/templates/admin/base_site.html
+++ b/django_admin_env_notice/templates/admin/base_site.html
@@ -12,9 +12,11 @@
         color: white;
         content: "{{ ENVIRONMENT_NAME }}";
         background-color: {{ ENVIRONMENT_COLOR }};
-        position: sticky;
-        top: 0;
-        z-index: 1000;
+        {% if ENVIRONMENT_FLOAT %}
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+        {% endif %}
     }
 </style>
 {% endif %}

--- a/django_admin_env_notice/templates/admin/base_site.html
+++ b/django_admin_env_notice/templates/admin/base_site.html
@@ -12,6 +12,9 @@
         color: white;
         content: "{{ ENVIRONMENT_NAME }}";
         background-color: {{ ENVIRONMENT_COLOR }};
+        position: sticky;
+        top: 0;
+        z-index: 1000;
     }
 </style>
 {% endif %}


### PR DESCRIPTION
Make the environment label visible while the page is scrolled, to avoid mistakes when it's not visible.