### PR TITLE
Add a nonce attribute if django-csp is in use

### DIFF
--- a/django_admin_env_notice/templates/admin/base_site.html
+++ b/django_admin_env_notice/templates/admin/base_site.html
@@ -2,7 +2,7 @@
 {% block extrastyle %}{{ block.super }}
 {% if ENVIRONMENT_NAME and ENVIRONMENT_COLOR %}
 <!-- Environment notice -->
-<style type="text/css">
+<style type="text/css"{% if request.csp_nonce %} nonce="{{ request.csp_nonce }}"{% endif %}>
     {{ ENVIRONMENT_ADMIN_SELECTOR }}:before {
         display: block;
         line-height: 35px;

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,3 +4,4 @@ flake8>=2.1.0
 tox>=1.7.0
 tox-travis
 codecov>=2.0.0
+django-csp

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -58,10 +58,12 @@ if django.VERSION >= (1, 10):
         "django.contrib.messages.middleware.MessageMiddleware",
         "django.middleware.common.CommonMiddleware",
         "django.contrib.auth.middleware.AuthenticationMiddleware",
+        "csp.middleware.CSPMiddleware",
     )
 else:
     MIDDLEWARE_CLASSES = (
         "django.contrib.sessions.middleware.SessionMiddleware",
         "django.middleware.common.CommonMiddleware",
         "django.contrib.auth.middleware.AuthenticationMiddleware",
+        "csp.middleware.CSPMiddleware",
     )


### PR DESCRIPTION
Should fix #9 