### PR TITLE
fix #22: sticky not sticking on long pages

### DIFF
--- a/django_admin_env_notice/templates/admin/base_site.html
+++ b/django_admin_env_notice/templates/admin/base_site.html
@@ -18,6 +18,12 @@
             z-index: 1000;
         {% endif %}
     }
+    {% if ENVIRONMENT_FLOAT %}
+    body {
+      /* workaround for sticky not sticking on long pages (see https://stackoverflow.com/a/59193260) */
+      height: auto;
+    }
+    {% endif %}
 </style>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
Fix for #22 (sticky not sticking on long pages).

Note I'm no CSS guru and don't understand why this fixes the issue. Am currently using this workaround and haven't noticed any side-effect, but will report if I do.

Cheers !